### PR TITLE
Deprecate Python 3.7 and test on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Deprecate Python 3.7 and test on Python 3.10 (:pr:`271`)
 * Document Fused RIME (:pr:`270`)
 * Add Multiton, LazyProxy and LazyProxyMultiton patterns (:pr:`269`)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
     "jax": ["jax >= 0.2.11", "jaxlib >= 0.1.65"],
     "scipy": ["scipy >= 1.4.0"],
     "astropy": ["astropy >= 4.0"],
-    "python-casacore": ["python-casacore >= 3.4.0"],
+    "python-casacore": ["python-casacore >= 3.4.0, != 3.5.0"],
     "ducc0": ["ducc0 >= 0.9.0"],
     "testing": ["pytest", "flaky", "pytest-flake8 >= 1.0.6", "flake8 >= 4.0.0, < 5.0.0"],
 }

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     keywords="codex-africanus",
     name="codex-africanus",
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
