### PR TITLE
Pin flake8 to >= 4.0.0 and < 5.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin flake8 to >= 4.0.0 and < 5.0.0 (:pr:`272`)
 * Document Fused RIME (:pr:`270`)
 * Add Multiton, LazyProxy and LazyProxyMultiton patterns (:pr:`269`)
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     "astropy": ["astropy >= 4.0"],
     "python-casacore": ["python-casacore >= 3.4.0"],
     "ducc0": ["ducc0 >= 0.9.0"],
-    "testing": ["pytest", "flaky", "pytest-flake8 >= 1.0.6"],
+    "testing": ["pytest", "flaky", "pytest-flake8 >= 4.0.0, < 5.0.0"],
 }
 
 with open(str(Path("africanus", "install", "extras_require.py")), "w") as f:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     "astropy": ["astropy >= 4.0"],
     "python-casacore": ["python-casacore >= 3.4.0"],
     "ducc0": ["ducc0 >= 0.9.0"],
-    "testing": ["pytest", "flaky", "pytest-flake8 >= 4.0.0, < 5.0.0"],
+    "testing": ["pytest", "flaky", "pytest-flake8 >= 1.0.6", "flake8 >= 4.0.0, < 5.0.0"],
 }
 
 with open(str(Path("africanus", "install", "extras_require.py")), "w") as f:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ extras_require = {
 }
 
 with open(str(Path("africanus", "install", "extras_require.py")), "w") as f:
+    f.write("# flake8: noqa")
     f.write("extras_require = {\n")
     for k, v in extras_require.items():
         f.write("   '%s': %s,\n" % (k, v))


### PR DESCRIPTION
Temporary workaround for https://github.com/tholo/pytest-flake8/issues/87

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
