### PR TITLE
Separate stokes and correlation dask dims. Disable feed rotation terms for less than four correlations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.4 (2023-03-08)
+------------------
+* Separate stokes and correlation dimensions in dask fused RIME (:pr:`273`)
+* Disallow feed rotation terms for RIME's containing less than four correlations (:pr:`273`)
+
 0.3.3 (2022-08-03)
 ------------------
 * Deprecate Python 3.7 and test on Python 3.10 (:pr:`271`)

--- a/africanus/experimental/rime/fused/dask.py
+++ b/africanus/experimental/rime/fused/dask.py
@@ -17,7 +17,7 @@ def rime_dask_wrapper(factory, names, nconcat_dims, *args):
     assert len(names) == len(args)
     out = factory(**dict(zip(names, args)))
     # (1) Reintroduce source dimension,
-    # (2) slice the existing dimes
+    # (2) slice the existing dimensions
     # (3) expand by the contraction dims which will
     #     be removed in the later dask reduction
     return out[(None,) + (slice(None),)*out.ndim + (None,)*nconcat_dims]
@@ -37,9 +37,10 @@ def rime(rime_spec, *args, **kw):
 
     # Source and concatenation dimension are reduced to 1 element
     adjust_chunks = {"source": 1, **{d: 1 for d in contract_dims}}
+    new_axes = {"corr": len(factory.rime_spec.corrs)}
 
     # This is needed otherwise, dask will call rime_dask_wrapper
-    # with dummy arugments to infer the output dtype.
+    # with dummy arguments to infer the output dtype.
     # This incurs memory allocations within numba, as well as
     # exceptions, leading to memory leaks as described
     # in https://github.com/numba/numba/issues/3263
@@ -53,6 +54,7 @@ def rime(rime_spec, *args, **kw):
                        *args,
                        concatenate=False,
                        adjust_chunks=adjust_chunks,
+                       new_axes=new_axes,
                        meta=meta)
 
     # Contract over source and concatenation dims

--- a/africanus/experimental/rime/fused/specification.py
+++ b/africanus/experimental/rime/fused/specification.py
@@ -50,6 +50,32 @@ class RimeSpecificationError(ValueError):
     pass
 
 
+def parse_stokes(stokes_string):
+    stokes = parse_str_list(stokes_string)
+
+    if (not isinstance(stokes, list) or
+            not all(isinstance(s, str) for s in stokes)):
+
+        raise RimeParseError(
+            f"Stokes specification must be of the form "
+            f"[I,Q,U,V]. Got {stokes}.")
+
+    return [s.upper() for s in stokes]
+
+
+def parse_corrs(corrs_string):
+    corrs = parse_str_list(corrs_string)
+
+    if (not isinstance(corrs, list) or
+            not all(isinstance(c, str) for c in corrs)):
+
+        raise RimeParseError(
+            f"Correlation specification must be of the form "
+            f"[XX,XY,YX,YY]. Got {corrs}.")
+
+    return [c.upper() for c in corrs]
+
+
 def parse_rime(rime: str):
     bits = [s.strip() for s in rime.split(":")]
 
@@ -72,26 +98,8 @@ def parse_rime(rime: str):
 
     stokes_bits, corr_bits = bits
 
-    stokes = parse_str_list(stokes_bits)
-    corrs = parse_str_list(corr_bits)
-
-    if (not isinstance(stokes, list) or
-            not all(isinstance(s, str) for s in stokes)):
-
-        raise RimeParseError(
-            f"Stokes specification must be of the form "
-            f"[I,Q,U,V]. Got {stokes}.")
-
-    if (not isinstance(corrs, list) or
-            not all(isinstance(c, str) for c in corrs)):
-
-        raise RimeParseError(
-            f"Correlation specification must be of the form "
-            f"[XX,XY,YX,YY]. Got {corrs}.")
-
-    stokes = [s.upper() for s in stokes]
-    corrs = [c.upper() for c in corrs]
-
+    stokes = parse_stokes(stokes_bits)
+    corrs = parse_corrs(corr_bits)
     equation = parse_str_list(rime_bits)
 
     if (not isinstance(equation, (tuple, list)) or

--- a/africanus/experimental/rime/fused/terms/brightness.py
+++ b/africanus/experimental/rime/fused/terms/brightness.py
@@ -131,8 +131,8 @@ class Brightness(Term):
         assert isinstance(spi_base, str)
 
         return {
-            "stokes": ("source", "corr"),
-            "spi": ("source", "spi", "corr"),
+            "stokes": ("source", "stokes"),
+            "spi": ("source", "spi", "stokes"),
             "ref_freq": ("source",),
             "chan_freq": ("chan",),
             "spi_base": None

--- a/africanus/experimental/rime/fused/terms/feed_rotation.py
+++ b/africanus/experimental/rime/fused/terms/feed_rotation.py
@@ -3,7 +3,7 @@ from africanus.experimental.rime.fused.terms.core import Term
 
 class FeedRotation(Term):
     """Feed Rotation Term"""
-    def __init__(self, configuration, feed_type):
+    def __init__(self, configuration, feed_type, corrs):
         if configuration not in {"left", "right"}:
             raise ValueError(f"FeedRotation configuration must "
                              f"be either 'left' or 'right'. "
@@ -13,6 +13,11 @@ class FeedRotation(Term):
             raise ValueError(f"FeedRotation feed_type must be "
                              f"either 'linear' or 'circular'. "
                              f"Got {feed_type}")
+
+        if len(corrs) != 4:
+            raise ValueError(f"Four correlations required for "
+                             f"feed rotation but {corrs} were "
+                             f"specified")
 
         super().__init__(configuration)
         self.feed_type = feed_type

--- a/africanus/experimental/rime/fused/tests/test_rime.py
+++ b/africanus/experimental/rime/fused/tests/test_rime.py
@@ -367,9 +367,9 @@ def test_fused_dask_rime(chunks, stokes_schema, corr_schema):
     }
 
     # Feed rotations only make sense if we have four correlations
-    equation_str = (f"(Lp, Ep, Kpq, Bpq, Eq, Lq)"
+    equation_str = ("(Lp, Ep, Kpq, Bpq, Eq, Lq)"
                     if ncorr == 4
-                    else f"(Ep, Kpq, Bpq, Eq)")
+                    else "(Ep, Kpq, Bpq, Eq)")
     rime_spec = RimeSpecification(f"{equation_str}: {stokes_to_corr}")
     dask_out = dask_rime(rime_spec, dask_dataset, convention="casa")
 

--- a/africanus/gps/kernels.py
+++ b/africanus/gps/kernels.py
@@ -33,13 +33,13 @@ def exponential_squared(x, xp, sigmaf, l, pspec=False):  # noqa: E741
     if pspec:
         N, D = x.shape
         if D != 1:
-            raise(NotImplementedError, "Only 1D pspecs supported")
+            raise NotImplementedError("Only 1D pspecs supported")
         if (x != xp).any():
-            raise(ValueError, "pspec only defined if x = xp")
+            raise ValueError("pspec only defined if x = xp")
         x = x.squeeze()
         delx = x[1] - x[0]
         if (x[1::] - x[0:-1] != delx).any():
-            raise(ValueError, "pspec only defined on regular grid")
+            raise ValueError("pspec only defined on regular grid")
         s = np.fft.fftshift(np.fft.fftfreq(N, d=delx))
         return np.sqrt(2*np.pi*l)*sigmaf**2.0*np.exp(-l**2*s**2/2.0)
     else:


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
