### PR TITLE
Adjust SPI code to handle negative/zero Stokes components.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.3.4 (2023-10-03)
 ------------------
+* Adjust SPI code to handle negative/zero Stokes components (:pr:`276`)
 * Separate stokes and correlation dimensions in dask fused RIME (:pr:`273`)
 * Disallow feed rotation terms for RIME's containing less than four correlations (:pr:`273`)
 * Update trove hash (:pr:`274`)

--- a/africanus/experimental/rime/fused/terms/brightness.py
+++ b/africanus/experimental/rime/fused/terms/brightness.py
@@ -191,26 +191,28 @@ class Brightness(Term):
 
                         for f in range(nchan):
                             freq_ratio = np.log(chan_freq[f] / rf)
-                            spec_model = np.log(stokes[s, p])
+                            spec_model = 0
 
                             for si in range(0, nspi):
                                 term = spi[s, si, p] * freq_ratio**(si + 1)
                                 spec_model += term
 
-                            spectral_model[s, f, p] = np.exp(spec_model)
+                            spectral_model[s, f, p] = \
+                                stokes[s, p] * np.exp(spec_model)
                 elif b == "log10":
                     for s in range(nsrc):
                         rf = ref_freq[s]
 
                         for f in range(nchan):
                             freq_ratio = np.log10(chan_freq[f] / rf)
-                            spec_model = np.log10(stokes[s, p])
+                            spec_model = 0
 
                             for si in range(0, nspi):
                                 term = spi[s, si, p] * freq_ratio**(si + 1)
                                 spec_model += term
 
-                            spectral_model[s, f, p] = 10**spec_model
+                            spectral_model[s, f, p] = \
+                                stokes[s, p] * 10**spec_model
                 else:
                     raise ValueError(
                         "spi_base not in (\"standard\", \"log\", \"log10\")")

--- a/africanus/experimental/rime/fused/terms/brightness.py
+++ b/africanus/experimental/rime/fused/terms/brightness.py
@@ -197,8 +197,9 @@ class Brightness(Term):
                                 term = spi[s, si, p] * freq_ratio**(si + 1)
                                 spec_model += term
 
-                            spectral_model[s, f, p] = \
+                            spectral_model[s, f, p] = (
                                 stokes[s, p] * np.exp(spec_model)
+                            )
                 elif b == "log10":
                     for s in range(nsrc):
                         rf = ref_freq[s]
@@ -211,8 +212,9 @@ class Brightness(Term):
                                 term = spi[s, si, p] * freq_ratio**(si + 1)
                                 spec_model += term
 
-                            spectral_model[s, f, p] = \
+                            spectral_model[s, f, p] = (
                                 stokes[s, p] * 10**spec_model
+                            )
                 else:
                     raise ValueError(
                         "spi_base not in (\"standard\", \"log\", \"log10\")")

--- a/africanus/experimental/rime/fused/tests/test_rime.py
+++ b/africanus/experimental/rime/fused/tests/test_rime.py
@@ -226,10 +226,10 @@ def test_fused_rime(chunks, stokes_schema, corr_schema):
     radec = np.random.random(size=(nsrc, 2))*1e-5
     phase_dir = np.random.random(2)*1e-5
     uvw = np.random.random(size=(nrow, 3))
-    chan_freq = np.linspace(.856e9, 2*.859e9, nchan)
+    chan_freq = np.linspace(.856e9, 2*.856e9, nchan)
     stokes = np.random.random(size=(nsrc, nstokes))
     spi = np.random.random(size=(nsrc, nspi, nstokes))
-    ref_freq = np.random.random(size=nsrc)*.856e9
+    ref_freq = np.random.uniform(low=.5*.856e9, high=4*.856e9, size=nsrc)
     lm = radec_to_lm(radec, phase_dir)
 
     dataset = {
@@ -257,18 +257,18 @@ def test_fused_rime(chunks, stokes_schema, corr_schema):
     assert np.count_nonzero(out) > .8 * out.size
 
     out = rime(f"(Kpq, Bpq): {stokes_to_corr}",
-               dataset, convention="fourier")
+               dataset, convention="fourier", spi_base="log")
 
     P = phase_delay(lm, uvw, chan_freq, convention="fourier")
-    SM = spectral_model(stokes, spi, ref_freq, chan_freq, base="std")
+    SM = spectral_model(stokes, spi, ref_freq, chan_freq, base="log")
     B = convert(SM, stokes_schema, corr_schema)
     expected = (P[:, :, :, None]*B[:, None, :, :]).sum(axis=0)
     assert_array_almost_equal(expected, out)
     assert np.count_nonzero(out) > .8 * out.size
 
-    out = rime(f"(Kpq, Bpq): {stokes_to_corr}", dataset)
+    out = rime(f"(Kpq, Bpq): {stokes_to_corr}", dataset, spi_base="log10")
     P = phase_delay(lm, uvw, chan_freq, convention="fourier")
-    SM = spectral_model(stokes, spi, ref_freq, chan_freq, base="std")
+    SM = spectral_model(stokes, spi, ref_freq, chan_freq, base="log10")
     B = convert(SM, stokes_schema, corr_schema)
     expected = (P[:, :, :, None]*B[:, None, :, :]).sum(axis=0)
     assert_array_almost_equal(expected, out)

--- a/africanus/experimental/rime/fused/tests/test_rime.py
+++ b/africanus/experimental/rime/fused/tests/test_rime.py
@@ -227,7 +227,9 @@ def test_fused_rime(chunks, stokes_schema, corr_schema):
     phase_dir = np.random.random(2)*1e-5
     uvw = np.random.random(size=(nrow, 3))
     chan_freq = np.linspace(.856e9, 2*.856e9, nchan)
-    stokes = np.random.random(size=(nsrc, nstokes))
+    # Make perfect stokes paramters i.e. I**2 = Q**2 + U**2 + V**2.
+    stokes = np.random.normal(size=(nsrc, nstokes))
+    stokes[:, 0] = np.sqrt((stokes[:, 1:] ** 2).sum(axis=-1))
     spi = np.random.random(size=(nsrc, nspi, nstokes))
     ref_freq = np.random.uniform(low=.5*.856e9, high=4*.856e9, size=nsrc)
     lm = radec_to_lm(radec, phase_dir)

--- a/africanus/model/spectral/spec_model.py
+++ b/africanus/model/spectral/spec_model.py
@@ -41,14 +41,16 @@ def numpy_spectral_model(stokes, spi, ref_freq, frequency, base):
             freq_ratio = np.log(frequency[None, :] / ref_freq[:, None])
             term = freq_ratio[:, None, :]**spi_exps[None, :, None]
             term = spi[:, :, p, None] * term
-            spectral_model[:, :, p] = (np.exp(np.log(stokes[:, p, None]) +
-                                              term.sum(axis=1)))
+            spectral_model[:, :, p] = (
+                stokes[:, p, None] * np.exp(term.sum(axis=1))
+            )
         elif b in ("log10", 2):
             freq_ratio = np.log10(frequency[None, :] / ref_freq[:, None])
             term = freq_ratio[:, None, :]**spi_exps[None, :, None]
             term = spi[:, :, p, None] * term
-            spectral_model[:, :, p] = (10**(np.log10(stokes[:, p, None]) +
-                                            term.sum(axis=1)))
+            spectral_model[:, :, p] = (
+                stokes[:, p, None] * 10**(term.sum(axis=1))
+            )
         else:
             raise ValueError("Invalid base %s" % base)
 
@@ -182,13 +184,15 @@ def spectral_model(stokes, spi, ref_freq, frequency, base=0):
 
                     for f in range(nchan):
                         freq_ratio = np.log(frequency[f] / rf)
-                        spec_model = np.log(estokes[s, p])
+                        spec_model = 0
 
                         for si in range(0, nspi):
                             term = espi[s, si, p] * freq_ratio**(si + 1)
                             spec_model += term
 
-                        spectral_model[s, f, p] = np.exp(spec_model)
+                        spectral_model[s, f, p] = (
+                            estokes[s, p] * np.exp(spec_model)
+                        )
 
             elif is_log10(b):
                 for s in range(nsrc):
@@ -196,13 +200,15 @@ def spectral_model(stokes, spi, ref_freq, frequency, base=0):
 
                     for f in range(nchan):
                         freq_ratio = np.log10(frequency[f] / rf)
-                        spec_model = np.log10(estokes[s, p])
+                        spec_model = 0
 
                         for si in range(0, nspi):
                             term = espi[s, si, p] * freq_ratio**(si + 1)
                             spec_model += term
 
-                        spectral_model[s, f, p] = 10**spec_model
+                        spectral_model[s, f, p] = (
+                            estokes[s, p] * 10**spec_model
+                        )
 
             else:
                 raise ValueError("Invalid base")

--- a/africanus/model/spectral/tests/test_spectral_model.py
+++ b/africanus/model/spectral/tests/test_spectral_model.py
@@ -12,7 +12,7 @@ from africanus.model.spectral.spec_model import (spectral_model,
 @pytest.fixture
 def flux():
     def impl(nsrc):
-        return np.random.random(nsrc)
+        return np.random.normal(size=nsrc)
 
     return impl
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
