### PR TITLE
Modify spectra calculation and thereby support negative flux in wsclean spectra

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,13 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Adjust SPI code to handle negative/zero Stokes components (:pr:`276`, :pr:`277`)
+
+
 0.3.4 (2023-10-03)
 ------------------
-* Adjust SPI code to handle negative/zero Stokes components (:pr:`276`)
 * Separate stokes and correlation dimensions in dask fused RIME (:pr:`273`)
 * Disallow feed rotation terms for RIME's containing less than four correlations (:pr:`273`)
 * Update trove hash (:pr:`274`)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
