### PR TITLE
Investigate BDA Overflagging

### DIFF
--- a/africanus/averaging/tests/test_bda_averaging.py
+++ b/africanus/averaging/tests/test_bda_averaging.py
@@ -54,7 +54,7 @@ def bda_test_map(request):
       [0, 0, 0, 0]],
      {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
 
-    # Inhomogenous flags per input bin, so we have partial contributions to output bins
+    # Heterogenous flags per input bin, so we have partial contributions to output bins
     ([[1, 1, 0, 0],
       [1, 0, 0, 1],
       [1, 0, 0, 1],

--- a/africanus/averaging/tests/test_bda_averaging.py
+++ b/africanus/averaging/tests/test_bda_averaging.py
@@ -46,7 +46,8 @@ def bda_test_map(request):
       [0, 0, 0, 0]],
      {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
 
-    # Homogenous flags per input bin, so we still have full contributions to output bins
+    # Homogenous flags per input bin,
+    # so we still have full contributions to output bins
     ([[1, 1, 0, 0],
       [1, 1, 0, 0],
       [1, 0, 0, 1],
@@ -54,7 +55,8 @@ def bda_test_map(request):
       [0, 0, 0, 0]],
      {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
 
-    # Heterogenous flags per input bin, so we have partial contributions to output bins
+    # Heterogenous flags per input bin,
+    # so we have partial contributions to output bins
     ([[1, 1, 0, 0],
       [1, 0, 0, 1],
       [1, 0, 0, 1],
@@ -63,11 +65,16 @@ def bda_test_map(request):
      {0: False, 1: False, 2: True, 3: True, 4: True, 5: False}),
 
 ])
-def test_bda_full_bin_contribution(inv_bda_test_map, bda_test_flags, full_bin_contribution):
+def test_bda_bin_contribution(inv_bda_test_map,
+                              bda_test_flags,
+                              full_bin_contribution):
     bda_test_flags = np.asarray(bda_test_flags)
 
+    # Test homogeneity of flags in input samples which
+    # contribute to output samples
     for out_row_id, (rows, chans) in inv_bda_test_map.items():
-        mixed_flags = len(set(bda_test_flags[r, c] for r, c in zip(rows, chans))) > 1
+        mixed_flags = len(set(bda_test_flags[r, c]
+                              for r, c in zip(rows, chans))) > 1
         assert full_bin_contribution[out_row_id] is not mixed_flags
 
 
@@ -155,7 +162,8 @@ def _effective_rowchan_map(flags, inv_bda_test_map):
             # Pass through all row-channels if the entire bin is flagged
             emap.append((rows, chans))
         else:
-            # Pass through only unflagged row-channels if some of the bin is flagged
+            # Pass through only unflagged row-channels if some of the
+            # bin is flagged
             it = ((r, c) for r, c in zip(rows, chans) if flags[r, c] == 0)
             emap.append(tuple(map(list, zip(*it))))
 

--- a/africanus/averaging/tests/test_bda_averaging.py
+++ b/africanus/averaging/tests/test_bda_averaging.py
@@ -17,6 +17,8 @@ from africanus.averaging.dask import bda as dask_bda
     # row 1 contains 2 channels
     # row 2 contains 3 channels
     # row 3 contains 1 channel
+    #
+    # 6 output bins total
     [[0, 0, 1, 1],
      [0, 0, 1, 1],
      [2, 3, 3, 4],
@@ -25,6 +27,48 @@ from africanus.averaging.dask import bda as dask_bda
 ])
 def bda_test_map(request):
     return np.asarray(request.param)
+
+
+@pytest.mark.parametrize("bda_test_flags, full_bin_contribution", [
+    # Everything flagged, input bins contribute fully to output bins
+    ([[1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 1]],
+     {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
+
+    # Everything unflagged, input bins contribute fully to output bins
+    ([[0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0]],
+     {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
+
+    # Homogenous flags per input bin, so we still have full contributions to output bins
+    ([[1, 1, 0, 0],
+      [1, 1, 0, 0],
+      [1, 0, 0, 1],
+      [1, 0, 0, 1],
+      [0, 0, 0, 0]],
+     {0: True, 1: True, 2: True, 3: True, 4: True, 5: True}),
+
+    # Inhomogenous flags per input bin, so we have partial contributions to output bins
+    ([[1, 1, 0, 0],
+      [1, 0, 0, 1],
+      [1, 0, 0, 1],
+      [1, 0, 0, 1],
+      [0, 0, 1, 0]],
+     {0: False, 1: False, 2: True, 3: True, 4: True, 5: False}),
+
+])
+def test_bda_full_bin_contribution(inv_bda_test_map, bda_test_flags, full_bin_contribution):
+    bda_test_flags = np.asarray(bda_test_flags)
+
+    for out_row_id, (rows, chans) in inv_bda_test_map.items():
+        mixed_flags = len(set(bda_test_flags[r, c] for r, c in zip(rows, chans))) > 1
+        assert full_bin_contribution[out_row_id] is not mixed_flags
 
 
 @pytest.fixture(params=[
@@ -108,8 +152,10 @@ def _effective_rowchan_map(flags, inv_bda_test_map):
 
     for _, (rows, chans) in sorted(inv_bda_test_map.items()):
         if flags[rows, chans].all():
+            # Pass through all row-channels if the entire bin is flagged
             emap.append((rows, chans))
         else:
+            # Pass through only unflagged row-channels if some of the bin is flagged
             it = ((r, c) for r, c in zip(rows, chans) if flags[r, c] == 0)
             emap.append(tuple(map(list, zip(*it))))
 


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
