### PR TITLE
Pin numba until such time @overload can be implemented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: pipenv graph
 
       - name: Run complete test suite
-        run: pipenv run py.test --flake8 -s -vvv africanus/
+        run: NUMBA_NRT_STATS=1 pipenv run py.test --flake8 -s -vvv africanus/
 
   deploy:
     needs: [test]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if not on_rtd:
         # astropy breaks with numpy 1.15.3
         # https://github.com/astropy/astropy/issues/7943
         "numpy >= 1.14.0, != 1.15.3",
-        "numba >= 0.53.1"
+        "numba >= 0.53.1, <0.59.0"
     ]
 
 extras_require = {


### PR DESCRIPTION
Closes #280 

- [ ] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
