### PR TITLE
Pin numba to < 0.59 due to pending @generated_jit deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: pipenv install .[testing]
 
       - name: Run base test suite
-        run: pipenv run py.test --flake8 -s -vvv africanus/
+        run: pipenv run  NUMBA_NRT_STATS=1 py.test --flake8 -s -vvv africanus/
 
       - name: List the measures directory
         run: curl ftp://ftp.astron.nl/outgoing/Measures/ > measures_dir.txt
@@ -79,7 +79,7 @@ jobs:
         run: pipenv graph
 
       - name: Run complete test suite
-        run: pipenv run py.test --flake8 -s -vvv africanus/
+        run: pipenv run NUMBA_NRT_STATS=1 py.test --flake8 -s -vvv africanus/
 
   deploy:
     needs: [test]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin numba to less than 0.59 in anticipation of @generated_jit deprecation (:pr:`284`)
 * Update trove hash (:pr:`279`)
 * Adjust SPI code to handle negative/zero Stokes components (:pr:`276`, :pr:`277`)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ if not on_rtd:
         # astropy breaks with numpy 1.15.3
         # https://github.com/astropy/astropy/issues/7943
         "numpy >= 1.14.0, != 1.15.3",
-        "numba >= 0.53.1"
+        # https://github.com/ratt-ru/codex-africanus/issues/283
+        "numba >= 0.53.1, < 0.59"
     ]
 
 extras_require = {


### PR DESCRIPTION
Closes #280 

Supercedes:
 - #281 

Related to:
 - #283 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
