### PR TITLE
Use packaging.version.Version instead of distuils.version.LooseVersion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Use `packaging.version.Version` instead of deprecated `distutils.version.LooseVersion` (:pr:`285`)
 * Pin numba to less than 0.59 in anticipation of @generated_jit deprecation (:pr:`284`)
 * Update trove hash (:pr:`279`)
 * Adjust SPI code to handle negative/zero Stokes components (:pr:`276`, :pr:`277`)

--- a/africanus/experimental/rime/fused/intrinsics.py
+++ b/africanus/experimental/rime/fused/intrinsics.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import partial
 
 import numba
@@ -17,7 +17,7 @@ from africanus.experimental.rime.fused.arguments import ArgumentPack
 from africanus.experimental.rime.fused.terms.core import StateStructRef
 
 try:
-    NUMBA_MAJOR, NUMBA_MINOR, _ = LooseVersion(numba.__version__).version
+    NUMBA_MAJOR, NUMBA_MINOR, _ = Version(numba.__version__).version
 except AttributeError:
     # Readthedocs
     NUMBA_MAJOR, NUMBA_MINOR = 0, 0

--- a/africanus/experimental/rime/fused/intrinsics.py
+++ b/africanus/experimental/rime/fused/intrinsics.py
@@ -17,10 +17,10 @@ from africanus.experimental.rime.fused.arguments import ArgumentPack
 from africanus.experimental.rime.fused.terms.core import StateStructRef
 
 try:
-    NUMBA_MAJOR, NUMBA_MINOR, _ = Version(numba.__version__).version
+    NUMBA_VERSION = Version(numba.__version__)
 except AttributeError:
     # Readthedocs
-    NUMBA_MAJOR, NUMBA_MINOR = 0, 0
+    NUMBA_VERSION = Version("0.0.0")
 
 
 def scalar_scalar(lhs, rhs):
@@ -696,7 +696,7 @@ class IntrinsicFactory:
             sampler_ir = list(map(compiler.run_frontend, samplers))
             ir_args = (state, s, r, t, f1, f2, a1, a2, c)
 
-            if NUMBA_MAJOR > 0 or NUMBA_MINOR >= 54:
+            if NUMBA_VERSION.major > 0 or NUMBA_VERSION.minor >= 54:
                 # NOTE(sjperkins)
                 # numba 0.54 wants a targetctx for type_inference_stage
                 # Assume we're dealing with a CPU Target  in order to derive


### PR DESCRIPTION
Closes #282 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
