### PR TITLE
Optionally check NRT allocations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Optionally check NRT allocations (:pr:`286`)
 * Pin numba to less than 0.59 in anticipation of @generated_jit deprecation (:pr:`284`)
 * Update trove hash (:pr:`279`)
 * Adjust SPI code to handle negative/zero Stokes components (:pr:`276`, :pr:`277`)

--- a/africanus/averaging/tests/test_bda_averaging.py
+++ b/africanus/averaging/tests/test_bda_averaging.py
@@ -368,21 +368,6 @@ def test_dask_bda_avg(vis_format):
             raise ValueError(f"Invalid vis_format: {vis_format}")
 
 
-@pytest.fixture
-def check_leaks():
-    import gc
-    from numba.core.runtime import rtsys
-
-    try:
-        yield None
-    finally:
-        gc.collect()
-
-    stats = rtsys.get_allocation_stats()
-    assert stats.alloc == stats.free
-    assert stats.mi_alloc == stats.mi_free
-
-
 @pytest.mark.parametrize("dtype", [np.complex64])
 def test_bda_output_arrays(dtype, check_leaks):
     from africanus.averaging.bda_avg import vis_output_arrays

--- a/africanus/averaging/tests/test_bda_averaging.py
+++ b/africanus/averaging/tests/test_bda_averaging.py
@@ -369,7 +369,7 @@ def test_dask_bda_avg(vis_format):
 
 
 @pytest.mark.parametrize("dtype", [np.complex64])
-def test_bda_output_arrays(dtype, check_leaks):
+def test_bda_output_arrays(dtype):
     from africanus.averaging.bda_avg import vis_output_arrays
     from numba import njit
 

--- a/africanus/conftest.py
+++ b/africanus/conftest.py
@@ -11,6 +11,7 @@ from africanus.util.testing import mark_in_pytest
 NUMBA_NRT_STATS_ENABLED = (
     os.environ.get("NUMBA_NRT_STATS", "false").lower() in {"true", "1"})
 
+
 @pytest.fixture(scope="function", autouse=NUMBA_NRT_STATS_ENABLED)
 def check_allocations():
     """ Check allocations match frees """

--- a/africanus/conftest.py
+++ b/africanus/conftest.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from numba.core.runtime import rtsys
 import pytest
 
 from africanus.util.testing import mark_in_pytest
 
 
-@pytest.fixture(scope="function", autouse=True)
+NUMBA_NRT_STATS_ENABLED = (
+    os.environ.get("NUMBA_NRT_STATS", "false").lower() in {"true", "1"})
+
+@pytest.fixture(scope="function", autouse=NUMBA_NRT_STATS_ENABLED)
 def check_allocations():
     """ Check allocations match frees """
     try:

--- a/africanus/conftest.py
+++ b/africanus/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 from africanus.util.testing import mark_in_pytest
 
+
 @pytest.fixture(scope="function", autouse=bool(numba.config.NRT_STATS))
 def check_allocations():
     """ Check allocations match frees """

--- a/africanus/conftest.py
+++ b/africanus/conftest.py
@@ -1,18 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import os
-
+import numba
 from numba.core.runtime import rtsys
 import pytest
 
 from africanus.util.testing import mark_in_pytest
 
-
-NUMBA_NRT_STATS_ENABLED = (
-    os.environ.get("NUMBA_NRT_STATS", "false").lower() in {"true", "1"})
-
-
-@pytest.fixture(scope="function", autouse=NUMBA_NRT_STATS_ENABLED)
+@pytest.fixture(scope="function", autouse=bool(numba.config.NRT_STATS))
 def check_allocations():
     """ Check allocations match frees """
     try:


### PR DESCRIPTION
Related to:
 - #284

The global `check_allocations` pytest fixture checks for leaks in internal Numba intrinsic code, but without `NUMBA_NRT_STATS` enabled, all tests will fail.

This change only enables the `check_allocations` fixture if `NUMBA_NRT_STATS` is positively set. This means that a developer can run `py.test` without the entire test suite failing. The downside is that numba intrinsic memory leaks might remain locally undiscovered, but these should be picked up by CI where `NUMBA_NRT_STATS=1 py.test` is called.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i africanus
  $ flake8 africanus
  $ pycodestyle africanus
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
