### PR TITLE
Cache numba kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     needs: check_skip
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    env:
+      NUMBA_CACHE_DIR: /tmp/numba-cache
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +41,22 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Restore repo times
+        uses: chetan/git-restore-mtime-action@v2
+
+      - name: Create Key and Numba Cache Directory
+        id: numba-key
+        run: |
+          mkdir -p ${{ env.NUMBA_CACHE_DIR }}
+          echo "timestamp=$(/bin/date -u '+%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      - name: Cache Numba Kernels
+        uses: actions/cache@v3
+        with:
+          key: numba-cache-${{ matrix.python-version }}-${{ steps.numba-key.outputs.timestamp }}
+          restore-keys: numba-cache-${{ matrix.python-version }}-
+          path: ${{ env.NUMBA_CACHE_DIR }}
 
       - name: Create a .env file
         run: |

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Cache numba kernels between CI runs (:pr:`294`)
+
 0.3.5 (2024-01-30)
 ------------------
 * Update setup.py metadata (:pr:`293`)


### PR DESCRIPTION
Uses a similar strategy to  https://github.com/ratt-ru/QuartiCal/pull/279/

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
