### PR TITLE
Work around numba #5929

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.3.7 (2024-05-23)
 ------------------
+* Workaround numba #5929 (:pr:`312`)
 * Fix bda overload to return an implementation (:pr:`307`)
 * Upgrade obsolete readthedocs configuration (:pr:`304`)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,13 @@
 History
 =======
 
-0.3.7 (2024-05-23)
+X.Y.Z (YYYY-MM-DD)
 ------------------
 * Workaround numba #5929 (:pr:`312`)
 * Restrict NumPy to less than 2.0.0 (:pr:`313`)
+
+0.3.7 (2024-05-23)
+------------------
 * Fix bda overload to return an implementation (:pr:`307`)
 * Upgrade obsolete readthedocs configuration (:pr:`304`)
 

--- a/africanus/averaging/tests/test_time_and_channel_averaging.py
+++ b/africanus/averaging/tests/test_time_and_channel_averaging.py
@@ -323,7 +323,9 @@ def test_averager(
     assert avg.weight_spectrum.shape == chan_avg_shape
     assert avg.sigma_spectrum.shape == chan_avg_shape
 
-    chan_ranges = np.nonzero(np.ediff1d(chan_map, to_begin=1, to_end=1))[0]
+    # https://github.com/numba/numba/issues/5929
+    one = np.array(1, dtype=chan_map.dtype)
+    chan_ranges = np.nonzero(np.ediff1d(chan_map, to_begin=one, to_end=one))[0]
 
     # Three python loops. Slow, but works...
     # Figure out some way to remove loops with numpy


### PR DESCRIPTION
Address the following unresolved numba issue:

- https://github.com/numba/numba/issues/5929

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
