### PR TITLE
Restrict numpy to < 2.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.3.7 (2024-05-23)
 ------------------
+* Restrict NumPy to less than 2.0.0 (:pr:`313`)
 * Fix bda overload to return an implementation (:pr:`307`)
 * Upgrade obsolete readthedocs configuration (:pr:`304`)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 requirements = [
     "appdirs >= 1.4.3",
     "decorator",
-    "numpy >= 1.14.0, != 1.15.3",
+    "numpy >= 1.14.0, != 1.15.3, < 2.0.0",
     "numba >= 0.53.1",
 ]
 


### PR DESCRIPTION
- python-casacore wheels are built against numpy < 2.0.0

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
