### PR TITLE
Fix nvcc compilation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix nvcc compilation (:pr:`316`)
 * Workaround numba #5929 (:pr:`312`)
 * Restrict NumPy to less than 2.0.0 (:pr:`313`)
 

--- a/africanus/util/nvcc.py
+++ b/africanus/util/nvcc.py
@@ -14,10 +14,10 @@ import tempfile
 
 from os.path import join as pjoin
 
-import distutils
-from distutils import errors
-from distutils import msvccompiler
-from distutils import unixccompiler
+import setuptools
+from setuptools import errors
+from setuptools._distutils.ccompiler import msvccompiler
+from setuptools._distutils.ccompiler import unixccompiler
 
 from africanus.util.code import format_code
 from africanus.util.requirements import requires_optional
@@ -106,7 +106,7 @@ def get_cuda_path():
 def get_nvcc_path():
     nvcc = os.environ.get("NVCC", None)
     if nvcc:
-        return distutils.split_quoted(nvcc)
+        return setuptools.split_quoted(nvcc)
 
     cuda_path = get_cuda_path()
     if cuda_path is None:

--- a/africanus/util/nvcc.py
+++ b/africanus/util/nvcc.py
@@ -16,8 +16,8 @@ from os.path import join as pjoin
 
 import setuptools
 from setuptools import errors
-from setuptools._distutils.ccompiler import msvccompiler
-from setuptools._distutils.ccompiler import unixccompiler
+import setuptools._distutils._msvccompiler as msvccompiler
+import setuptools._distutils.unixccompiler as unixccompiler
 
 from africanus.util.code import format_code
 from africanus.util.requirements import requires_optional


### PR DESCRIPTION
distutils is deprecated.

- https://github.com/pypa/setuptools/issues/4620

- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
