### PR TITLE
Support numpy 2 and python-casacore 3.6.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 0.3.8 (2024-09-29)
 ------------------
+* Update to NumPy 2.0.0 (:pr:`317`)
+* Update to python-casacore 3.6.1 (:pr:`317`)
 * Test on Python 3.12 (:pr:`318`)
 * Deprecate Python 3.9 (:pr:`318`)
 * Fix nvcc compilation (:pr:`316`)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 requirements = [
     "appdirs >= 1.4.3",
     "decorator",
-    "numpy >= 1.14.0, != 1.15.3, < 2.0.0",
+    "numpy >= 2.0.0",
     "numba >= 0.53.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {
     "jax": ["jax >= 0.2.11", "jaxlib >= 0.1.65"],
     "scipy": ["scipy >= 1.4.0"],
     "astropy": ["astropy >= 4.0"],
-    "python-casacore": ["python-casacore >= 3.4.0, != 3.5.0"],
+    "python-casacore": ["python-casacore >= 3.6.1"],
     "ducc0": ["ducc0 >= 0.9.0"],
     "testing": ["pytest", "flaky"],
 }


### PR DESCRIPTION
Now that python-casacore 3.6.1 has been released, NumPy 2.0.0 can be used

-  #313 

- [ ] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
