### PR TITLE
Remove tuple allocation within beam cube inner loops

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.4.1 (2024-11-05)
+------------------
+* Remove tuple allocation in beam cube inner loops (:pr:`337`)
+
 0.4.0 (2024-11-01)
 ------------------
 * Upgrade readthedocs to PyData Sphinx Theme (:pr:`323`)

--- a/africanus/experimental/rime/fused/terms/cube_dde.py
+++ b/africanus/experimental/rime/fused/terms/cube_dde.py
@@ -235,35 +235,35 @@ class BeamCubeDDE(Term):
                                 md = vm - gm0
 
                                 # Zero the accumulators
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     absc_sum[co] = 0
                                     corr_sum[co] = 0
 
                                 # Lower cube
                                 weight = (1.0 - ld) * (1.0 - md) * nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl0, gm0, gc0, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = ld * (1.0 - md) * nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl1, gm0, gc0, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = (1.0 - ld) * md * nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl0, gm1, gc0, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = ld * md * nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl1, gm1, gc0, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
@@ -271,34 +271,34 @@ class BeamCubeDDE(Term):
                                 # Upper cube
                                 weight = (1.0 - ld) * (1.0 - md) * inv_nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl0, gm0, gc1, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = ld * (1.0 - md) * inv_nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl1, gm0, gc1, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = (1.0 - ld) * md * inv_nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl0, gm1, gc1, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 weight = ld * md * inv_nud
 
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     value = beam[gl1, gm1, gc1, co]
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
                                 # Assign interpolated values
-                                for co in range(ncorr):
+                                for co in numba.literal_unroll(range(ncorr)):
                                     div = np.abs(corr_sum[co])
                                     value = corr_sum[co] * absc_sum[co]
 

--- a/africanus/experimental/rime/fused/terms/cube_dde.py
+++ b/africanus/experimental/rime/fused/terms/cube_dde.py
@@ -174,6 +174,9 @@ class BeamCubeDDE(Term):
                 (nsrc, ntime, nfeed, nantenna, nchan, ncorr), beam.dtype
             )
 
+            corr_sum = np.zeros(ncorr, beam.dtype)
+            absc_sum = np.zeros(ncorr, beam.real.dtype)
+
             for s in range(nsrc):
                 l = lm[s, 0]  # noqa
                 m = lm[s, 1]
@@ -231,114 +234,68 @@ class BeamCubeDDE(Term):
                                 ld = vl - gl0
                                 md = vm - gm0
 
-                                corr_sum = zero_vis(beam.dtype.type(0))
-                                absc_sum = zero_vis(beam.real.dtype.type(0))
+                                # Zero the accumulators
+                                for co in range(ncorr):
+                                    absc_sum[co] = 0
+                                    corr_sum[co] = 0
 
                                 # Lower cube
                                 weight = (1.0 - ld) * (1.0 - md) * nud
 
                                 for co in range(ncorr):
                                     value = beam[gl0, gm0, gc0, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = ld * (1.0 - md) * nud
 
                                 for co in range(ncorr):
                                     value = beam[gl1, gm0, gc0, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = (1.0 - ld) * md * nud
 
                                 for co in range(ncorr):
                                     value = beam[gl0, gm1, gc0, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = ld * md * nud
 
                                 for co in range(ncorr):
                                     value = beam[gl1, gm1, gc0, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 # Upper cube
                                 weight = (1.0 - ld) * (1.0 - md) * inv_nud
 
                                 for co in range(ncorr):
                                     value = beam[gl0, gm0, gc1, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = ld * (1.0 - md) * inv_nud
 
                                 for co in range(ncorr):
                                     value = beam[gl1, gm0, gc1, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = (1.0 - ld) * md * inv_nud
 
                                 for co in range(ncorr):
                                     value = beam[gl0, gm1, gc1, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 weight = ld * md * inv_nud
 
                                 for co in range(ncorr):
                                     value = beam[gl1, gm1, gc1, co]
-                                    absc_sum = tuple_setitem(
-                                        absc_sum,
-                                        co,
-                                        weight * np.abs(value) + absc_sum[co],
-                                    )
-                                    corr_sum = tuple_setitem(
-                                        corr_sum, co, weight * value + corr_sum[co]
-                                    )
+                                    absc_sum[co] += weight * np.abs(value)
+                                    corr_sum[co] += weight * value
 
                                 for co in range(ncorr):
                                     div = np.abs(corr_sum[co])
@@ -347,10 +304,7 @@ class BeamCubeDDE(Term):
                                     if div != 0.0:
                                         value /= div
 
-                                    corr_sum = tuple_setitem(corr_sum, co, value)
-
-                                for co in range(ncorr):
-                                    sampled_beam[s, t, f, a, c, co] = corr_sum[co]
+                                    sampled_beam[s, t, f, a, c, co] = value
 
             return sampled_beam
 

--- a/africanus/experimental/rime/fused/terms/cube_dde.py
+++ b/africanus/experimental/rime/fused/terms/cube_dde.py
@@ -297,6 +297,7 @@ class BeamCubeDDE(Term):
                                     absc_sum[co] += weight * np.abs(value)
                                     corr_sum[co] += weight * value
 
+                                # Assign interpolated values
                                 for co in range(ncorr):
                                     div = np.abs(corr_sum[co])
                                     value = corr_sum[co] * absc_sum[co]


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s africanus
  ```

  If the pre-commit tests fail, install and
  run the pre-commit hooks in your development
  virtuale environment:

  ```bash
  $ pip install pre-commit
  $ pre-commit install
  $ pre-commit run -a
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```bash
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview codex-africanus start -->
----
📚 Documentation preview 📚: https://codex-africanus--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview codex-africanus end -->